### PR TITLE
fix coors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,4 @@ API_KEY=
 API_SECRET=
 
 SENDGRID_API_KEY=
-ALLOWED_ORIGIN=
+ALLOWED_ORIGIN=https://localhost,https://vercel

--- a/src/server.js
+++ b/src/server.js
@@ -17,10 +17,21 @@ export const startServer = () => {
 
   const allowedOrigin = env(ENV_VARS.ALLOWED_ORIGIN);
 
+  const corsOptions = {
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigin.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
+    credentials: true,
+  };
+
   app.use(express.json());
   app.use(
     cors({
-      origin: allowedOrigin,
+      origin: corsOptions,
       credentials: true,
     }),
   );
@@ -28,7 +39,7 @@ export const startServer = () => {
   app.options(
     '*',
     cors({
-      origin: allowedOrigin,
+      origin: corsOptions,
       credentials: true,
     }),
   );


### PR DESCRIPTION
The new configuration should allow adding multiple domains to those allowed in coors. References are entered to the .env file separated by commas. for example ALLOWED_ORIGIN=https://localhost.com,https://vercel.com